### PR TITLE
Update repository and homepage fields in package.json

### DIFF
--- a/.changeset/tiny-mails-kick.md
+++ b/.changeset/tiny-mails-kick.md
@@ -1,0 +1,5 @@
+---
+"@wanews/apple-news-format": patch
+---
+
+Update repository and homepage fields in package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wanews/apple-news-format",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wanews/apple-news-format",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "pre-push": "npm run lint && npm test"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sevenwestmedia-labs/apple-news-format.git"
+  },
+  "homepage": "https://github.com/sevenwestmedia-labs/apple-news-format#readme",
   "keywords": [
     "apple news",
     "apple-news",
@@ -34,8 +39,7 @@
     "typescript"
   ],
   "author": {
-    "name": "Robert Fairley",
-    "email": "rrafairley@gmail.com"
+    "name": "Robert Fairley"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
- Add information in homepage and repository fields for package.json to create link / ref from npm release to GitHub
- Remove author email for now due to privacy / potentially un-related updates